### PR TITLE
Handle Spotify authentication better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config.yaml
+token.json
 generated/
 
 # Created by https://www.toptal.com/developers/gitignore/api/linux,windows,macos,visualstudiocode,vim,go

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1,6 +1,7 @@
 spotify:
   clientId: dwa
   clientSecret: dwa
+  tokenFile: token.json
 server:
   host: localhost
   port: 8080

--- a/lib/spotify/errors.go
+++ b/lib/spotify/errors.go
@@ -1,0 +1,8 @@
+package spotify
+
+type NotAuthenticatedError struct {
+}
+
+func (e NotAuthenticatedError) Error() string {
+	return "client is not authenticated yet"
+}

--- a/lib/spotify/spotify.go
+++ b/lib/spotify/spotify.go
@@ -39,12 +39,8 @@ func callSpotify[R *Q, Q any](ctx context.Context, spot *Spotify, f func(ctx con
 	var err error
 
 	if spot.Client == nil {
+		// TODO: return a custom error type
 		return nil, fmt.Errorf("client is not authenticated yet")
-	}
-
-	spot.Client, err = spot.auth.checkClient(ctx, spot.Client)
-	if err != nil {
-		return nil, err
 	}
 
 	response, err := f(ctx, opts...)

--- a/lib/spotify/spotify.go
+++ b/lib/spotify/spotify.go
@@ -2,7 +2,6 @@ package spotify
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/albe2669/spotify-viewer/utils"
 	"github.com/labstack/echo/v4"
@@ -40,7 +39,7 @@ func callSpotify[R *Q, Q any](ctx context.Context, spot *Spotify, f func(ctx con
 
 	if spot.Client == nil {
 		// TODO: return a custom error type
-		return nil, fmt.Errorf("client is not authenticated yet")
+		return nil, NotAuthenticatedError{}
 	}
 
 	response, err := f(ctx, opts...)

--- a/lib/spotify/spotify.go
+++ b/lib/spotify/spotify.go
@@ -1,6 +1,9 @@
 package spotify
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/albe2669/spotify-viewer/utils"
 	"github.com/labstack/echo/v4"
 	spotifyLib "github.com/zmb3/spotify/v2"
@@ -24,10 +27,35 @@ func (s *Spotify) SetupRoutes(e *echo.Echo) {
 }
 
 func (s *Spotify) Authenticate() {
-
 	go func() {
 		s.Client = s.auth.waitForClient()
 	}()
 
 	s.auth.authenticate()
+}
+
+// Don't question it: https://groups.google.com/g/golang-nuts/c/y9IvZgiNowk
+func callSpotify[R *Q, Q any](ctx context.Context, spot *Spotify, f func(ctx context.Context, opts ...spotifyLib.RequestOption) (R, error), opts ...spotifyLib.RequestOption) (R, error) {
+	var err error
+
+	if spot.Client == nil {
+		return nil, fmt.Errorf("client is not authenticated yet")
+	}
+
+	spot.Client, err = spot.auth.checkClient(ctx, spot.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := f(ctx, opts...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (s *Spotify) GetPlayerState(ctx context.Context) (*spotifyLib.PlayerState, error) {
+	return callSpotify(ctx, s, s.Client.PlayerState)
 }

--- a/lib/spotify/spotify.go
+++ b/lib/spotify/spotify.go
@@ -24,9 +24,10 @@ func (s *Spotify) SetupRoutes(e *echo.Echo) {
 }
 
 func (s *Spotify) Authenticate() {
-	s.auth.authenticate()
 
 	go func() {
 		s.Client = s.auth.waitForClient()
 	}()
+
+	s.auth.authenticate()
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Spotify struct {
 		ClientID     string `yaml:"clientId"`
 		ClientSecret string `yaml:"clientSecret"`
+		TokenFile    string `yaml:"tokenFile"`
 	}
 	Server struct {
 		Host string `yaml:"host"`


### PR DESCRIPTION
This PR makes the following changes to vastly improve the authentication flow to the Spotify servers:
- Attempt to read the token from a configured file
- When getting a token from Spotify write it to said faile
- Wrap all API calls in a callSpotify tool that checks if the token needs to be refreshed

Commits:
- **Create player endpoint to test**
- **Read and write token from file\n\nCo-authored-by: Slug-Boi <theis.p.holm@gmail.com>**
- **Add token to gitignore**
- **Better auth flow**
